### PR TITLE
Lt 2926 timestamp public events

### DIFF
--- a/src/MarginTrading.Backend.Contracts/Workflow/Liquidation/Events/LiquidationResumedEvent.cs
+++ b/src/MarginTrading.Backend.Contracts/Workflow/Liquidation/Events/LiquidationResumedEvent.cs
@@ -24,5 +24,14 @@ namespace MarginTrading.Backend.Contracts.Workflow.Liquidation.Events
         
         [Key(4)]
         public List<string> PositionsLiquidatedBySpecialLiquidation { get; set; }
+
+        [Key(5)]
+        public LiquidationTypeContract LiquidationType { get; set; }
+
+        [Key(6)]
+        public string AccountId { get; set; }
+
+        [Key(7)]
+        public string AssetPairId { get; set; }
     }
 }

--- a/src/MarginTrading.Backend.Contracts/Workflow/Liquidation/Events/LiquidationResumedEvent.cs
+++ b/src/MarginTrading.Backend.Contracts/Workflow/Liquidation/Events/LiquidationResumedEvent.cs
@@ -5,10 +5,10 @@ using System;
 using System.Collections.Generic;
 using MessagePack;
 
-namespace MarginTrading.Backend.Services.Workflow.Liquidation.Events
+namespace MarginTrading.Backend.Contracts.Workflow.Liquidation.Events
 {
     [MessagePackObject]
-    public class LiquidationResumedInternalEvent
+    public class LiquidationResumedEvent
     {
         [Key(0)]
         public string OperationId { get; set; }

--- a/src/MarginTrading.Backend.Contracts/Workflow/Liquidation/Events/LiquidationStartedEvent.cs
+++ b/src/MarginTrading.Backend.Contracts/Workflow/Liquidation/Events/LiquidationStartedEvent.cs
@@ -14,5 +14,14 @@ namespace MarginTrading.Backend.Contracts.Workflow.Liquidation.Events
         
         [Key(1)]
         public DateTime CreationTime { get; set; }
+
+        [Key(2)]
+        public LiquidationTypeContract LiquidationType { get; set; }
+
+        [Key(3)]
+        public string AccountId { get; set; }
+
+        [Key(4)]
+        public string AssetPairId { get; set; }
     }
 }

--- a/src/MarginTrading.Backend.Contracts/Workflow/Liquidation/Events/LiquidationStartedEvent.cs
+++ b/src/MarginTrading.Backend.Contracts/Workflow/Liquidation/Events/LiquidationStartedEvent.cs
@@ -4,10 +4,10 @@
 using System;
 using MessagePack;
 
-namespace MarginTrading.Backend.Services.Workflow.Liquidation.Events
+namespace MarginTrading.Backend.Contracts.Workflow.Liquidation.Events
 {
     [MessagePackObject]
-    public class LiquidationStartedInternalEvent
+    public class LiquidationStartedEvent
     {
         [Key(0)]
         public string OperationId { get; set; }

--- a/src/MarginTrading.Backend.Core/Workflow/LiquidationOperationData.cs
+++ b/src/MarginTrading.Backend.Core/Workflow/LiquidationOperationData.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2019 Lykke Corp.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using MarginTrading.Backend.Core.Orders;
 
@@ -8,6 +9,7 @@ namespace MarginTrading.Backend.Core
 {
     public class LiquidationOperationData : OperationDataBase<LiquidationOperationState>
     {
+        public DateTime StartedAt { get; set; }
         public string AccountId { get; set; }
         public string AssetPairId { get; set; }
         public PositionDirection? Direction { get; set; }

--- a/src/MarginTrading.Backend.Services/Modules/CqrsModule.cs
+++ b/src/MarginTrading.Backend.Services/Modules/CqrsModule.cs
@@ -368,8 +368,8 @@ namespace MarginTrading.Backend.Services.Modules
                 .ListeningEvents(
                     typeof(LiquidationFailedEvent),
                     typeof(LiquidationFinishedEvent),
-                    typeof(LiquidationResumedInternalEvent),
-                    typeof(LiquidationStartedInternalEvent),
+                    typeof(LiquidationResumedEvent),
+                    typeof(LiquidationStartedEvent),
                     typeof(NotEnoughLiquidityInternalEvent),
                     typeof(PositionsLiquidationFinishedInternalEvent),
                     typeof(MarketStateChangedEvent)
@@ -395,8 +395,8 @@ namespace MarginTrading.Backend.Services.Modules
                 .PublishingEvents(
                     typeof(LiquidationFailedEvent),
                     typeof(LiquidationFinishedEvent),
-                    typeof(LiquidationResumedInternalEvent),
-                    typeof(LiquidationStartedInternalEvent),
+                    typeof(LiquidationResumedEvent),
+                    typeof(LiquidationStartedEvent),
                     typeof(NotEnoughLiquidityInternalEvent),
                     typeof(PositionsLiquidationFinishedInternalEvent)
                 )

--- a/src/MarginTrading.Backend.Services/Workflow/Liquidation/LiquidationCommandsHandler.cs
+++ b/src/MarginTrading.Backend.Services/Workflow/Liquidation/LiquidationCommandsHandler.cs
@@ -161,7 +161,10 @@ namespace MarginTrading.Backend.Services.Workflow.Liquidation
                 publisher.PublishEvent(new LiquidationStartedEvent
                 {
                     OperationId = command.OperationId,
-                    CreationTime = _dateService.Now()
+                    CreationTime = _dateService.Now(),
+                    AssetPairId = executionInfo.Data.AssetPairId,
+                    AccountId = executionInfo.Data.AccountId,
+                    LiquidationType = executionInfo.Data.LiquidationType.ToType<LiquidationTypeContract>()
                 });
             }
         }
@@ -452,7 +455,10 @@ namespace MarginTrading.Backend.Services.Workflow.Liquidation
                     CreationTime = _dateService.Now(),
                     Comment = command.Comment,
                     IsCausedBySpecialLiquidation = command.IsCausedBySpecialLiquidation,
-                    PositionsLiquidatedBySpecialLiquidation = command.PositionsLiquidatedBySpecialLiquidation
+                    PositionsLiquidatedBySpecialLiquidation = command.PositionsLiquidatedBySpecialLiquidation,
+                    AccountId = executionInfo.Data.AccountId,
+                    AssetPairId = executionInfo.Data.AssetPairId,
+                    LiquidationType = executionInfo.Data.LiquidationType.ToType<LiquidationTypeContract>()
                 });
             }
             else

--- a/src/MarginTrading.Backend.Services/Workflow/Liquidation/LiquidationCommandsHandler.cs
+++ b/src/MarginTrading.Backend.Services/Workflow/Liquidation/LiquidationCommandsHandler.cs
@@ -158,7 +158,7 @@ namespace MarginTrading.Backend.Services.Workflow.Liquidation
                     $"Publish_LiquidationStartedInternalEvent:" +
                     $"{command.OperationId}");
                 
-                publisher.PublishEvent(new LiquidationStartedInternalEvent
+                publisher.PublishEvent(new LiquidationStartedEvent
                 {
                     OperationId = command.OperationId,
                     CreationTime = _dateService.Now()
@@ -446,7 +446,7 @@ namespace MarginTrading.Backend.Services.Workflow.Liquidation
                 (!command.ResumeOnlyFailed || executionInfo.Data.State == LiquidationOperationState.Failed) ||
                 executionInfo.Data.State == LiquidationOperationState.SpecialLiquidationStarted)
             {
-                publisher.PublishEvent(new LiquidationResumedInternalEvent
+                publisher.PublishEvent(new LiquidationResumedEvent
                 {
                     OperationId = command.OperationId,
                     CreationTime = _dateService.Now(),

--- a/src/MarginTrading.Backend.Services/Workflow/Liquidation/LiquidationCommandsHandler.cs
+++ b/src/MarginTrading.Backend.Services/Workflow/Liquidation/LiquidationCommandsHandler.cs
@@ -136,6 +136,7 @@ namespace MarginTrading.Backend.Services.Workflow.Liquidation
                         LiquidationType = command.LiquidationType,
                         OriginatorType = command.OriginatorType,
                         AdditionalInfo = command.AdditionalInfo,
+                        StartedAt = command.CreationTime
                     }
                 ));
             

--- a/src/MarginTrading.Backend.Services/Workflow/Liquidation/LiquidationSaga.cs
+++ b/src/MarginTrading.Backend.Services/Workflow/Liquidation/LiquidationSaga.cs
@@ -61,7 +61,7 @@ namespace MarginTrading.Backend.Services.Workflow.Liquidation
         }
         
         [UsedImplicitly]
-        public async Task Handle(LiquidationStartedInternalEvent e, ICommandSender sender)
+        public async Task Handle(LiquidationStartedEvent e, ICommandSender sender)
         {
             var executionInfo = await _operationExecutionInfoRepository.GetAsync<LiquidationOperationData>(
                 operationName: OperationName,
@@ -79,7 +79,7 @@ namespace MarginTrading.Backend.Services.Workflow.Liquidation
                 LiquidatePositionsIfAnyAvailable(e.OperationId, executionInfo.Data, sender);
 
                 _chaosKitty.Meow(
-                    $"{nameof(LiquidationStartedInternalEvent)}:" +
+                    $"{nameof(LiquidationStartedEvent)}:" +
                     $"Save_OperationExecutionInfo:" +
                     $"{e.OperationId}");
 
@@ -197,7 +197,7 @@ namespace MarginTrading.Backend.Services.Workflow.Liquidation
         }
         
         [UsedImplicitly]
-        public async Task Handle(LiquidationResumedInternalEvent e, ICommandSender sender)
+        public async Task Handle(LiquidationResumedEvent e, ICommandSender sender)
         {
             var executionInfo = await _operationExecutionInfoRepository.GetAsync<LiquidationOperationData>(
                 operationName: OperationName,


### PR DESCRIPTION
- do not close orders that were opened later then saga started
- Make LiquidationStarted/ LiquidationResumed evts public availiable
-  Add and fill LiquidationType, AssetPairId, AccountId props to LiquidationStarted/LiquidationResumed evts (should be used in activities)